### PR TITLE
fix(config.py): Fixes bug in load_from_file exception handling

### DIFF
--- a/cogito/core/config.py
+++ b/cogito/core/config.py
@@ -26,12 +26,9 @@ class ConfigFile(BaseModel):
             with open(file_path, "r") as file:
                 yaml_data = yaml.safe_load(file)
             return cls(**yaml_data)
-        except FileNotFoundError as e:
-            logging.info(f"Config file not found: {file_path}. Empty config will be used. {e}")
         except Exception as e:
-            logging.error(f"Error loading config file: {file_path}. Empty config will be used. {e}")
-        finally:
-            logging.debug(f"Starting up with empty config.")
+            logging.error(f"Error loading config file: {file_path}: {e}")
+            logging.error(f"Starting up with empty config.")
             return cls(
                     name="Cogito ergo sum",
                     description="An API for inference and reasoning with an amazing user interface",


### PR DESCRIPTION
This pull request includes changes to the error handling in the `load_from_file` method of the `ConfigFile` class in `cogito/core/config.py`. The most important changes include removing the handling of `FileNotFoundError` and modifying the logging statements for better clarity.

Error handling improvements:

* Removed specific handling for `FileNotFoundError` and consolidated the logging of errors into a single `except` block.
* Updated the logging statements to provide clearer information when an error occurs while loading the config file.