### PR TITLE
fix(cogito/core/app.py): remove unused import and re-import correct m…

### DIFF
--- a/cogito/core/app.py
+++ b/cogito/core/app.py
@@ -11,7 +11,7 @@ from cogito.api.handlers import (
     create_predictor_handler,
     health_check_handler,
 )
-from core.utils import get_predictor_handler_return_type
+from cogito.core.utils import get_predictor_handler_return_type
 from cogito.core.config import ConfigFile
 from cogito.core.utils import load_predictor
 


### PR DESCRIPTION
…odule for get_predictor_handler_return_type

- Delete unnecessary import from core.utils
- Import cogito.core.utils correctly
- Update Application class to handle None return from get_predictor_handler_return_type function

This pull request includes a small change to the import statement in the `cogito/core/app.py` file. The change updates the import path for the `get_predictor_handler_return_type` function to reflect its correct location within the `cogito.core.utils` module.

* [`cogito/core/app.py`](diffhunk://#diff-a1174d8945fa2a12721fbd85c4d5479be3d8c134344d353169b2f062d0997d39L14-R14): Updated the import path for `get_predictor_handler_return_type` from `core.utils` to `cogito.core.utils`.