### PR TITLE
fix: Changes JSONResponse importation

### DIFF
--- a/cogito/api/responses.py
+++ b/cogito/api/responses.py
@@ -1,7 +1,7 @@
 from typing import Any
 
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from starlette.responses import JSONResponse
 
 
 class ResultResponse(BaseModel):


### PR DESCRIPTION
Closes #24 

This pull request includes a minor change to the `cogito/api/responses.py` file. The change replaces the import of `JSONResponse` from `starlette.responses` with an import from `fastapi.responses`.

* [`cogito/api/responses.py`](diffhunk://#diff-4a696905907d0ef893d903ced32c3e4c27308ccf81256c8e3641a690f3c82000R3-L4): Replaced the import of `JSONResponse` from `starlette.responses` with an import from `fastapi.responses`.Fastapi provides fastapi.responses.JSONResponse class to map starlette.JSONResponse