### PR TITLE
test: renames test file name and fixes test called method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help help-variables install dist upload clean
+.PHONY: all help help-variables install dist upload clean run-test dependencies-dev-install
 
 PYTHON_VERSION ?= 3.10
 REPOSITORY?=testpypi
@@ -71,7 +71,7 @@ dependencies-dev-install: .venv ## Install the development dependencies
 
 ##@ Testing commands
 
-run-test: dev-dependencies ## Run the tests
+run-test: dependencies-dev-install ## Run the tests
 	@. .venv/bin/activate && python -m pytest
 
 ##@ PyPi commands

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ dependencies-dev-install: .venv ## Install the development dependencies
 
 ##@ Testing commands
 
-run-test: dependencies-dev-install ## Run the tests
+run-test: .venv dependencies-dev-install ## Run the tests
 	@. .venv/bin/activate && python -m pytest
 
 ##@ PyPi commands

--- a/tests/core/utils/test_wrap_handler.py
+++ b/tests/core/utils/test_wrap_handler.py
@@ -3,13 +3,13 @@ from pydantic import BaseModel
 from inferia.core.utils import wrap_handler
 
 
-def test_validate_handler_str_input_str_output():
+def test_wrap_handler_str_output():
     class MockPredictor:
         def predict(self, input: str) -> str:
             return f"Hello, {input}"
 
     original_handler = MockPredictor().predict
-    wrapped_handler = wrap_handler("MockPredictor", original_handler)
+    wrapped_handler = wrap_handler("predict:MockPredictor", original_handler)
 
     class InputModel(BaseModel):
         input: str
@@ -19,13 +19,13 @@ def test_validate_handler_str_input_str_output():
     assert response == "Hello, World"
 
 
-def test_validate_handler_float_input_int_output():
+def test_wrap_handler_float_input_int_output():
     class MockPredictor:
         def predict(self, input: float) -> int:
             return int(input)
 
     original_handler = MockPredictor().predict
-    wrapped_handler = wrap_handler("MockPredictor", original_handler)
+    wrapped_handler = wrap_handler("predict:MockPredictor", original_handler)
 
     class InputModel(BaseModel):
         input: float
@@ -35,7 +35,7 @@ def test_validate_handler_float_input_int_output():
     assert response == 3
 
 
-def test_validate_handler_pydantic_input_str_output():
+def test_wrap_handler_base_model_input_str_output():
 
     class MyModel(BaseModel):
         input: str
@@ -45,8 +45,11 @@ def test_validate_handler_pydantic_input_str_output():
             return f"Hello, {input}"
 
     original_handler = MockPredict().predict
-    wrapped_handler = wrap_handler("MockPredict", original_handler)
+    wrapped_handler = wrap_handler("predict:MockPredictor", original_handler)
 
     input_data = MyModel(input="World")
     response = wrapped_handler(input_data)
     assert response == "Hello, World"
+    wrapped_handler_annotations = wrapped_handler.__annotations__
+    assert issubclass(wrapped_handler_annotations["input"], BaseModel)
+    assert wrapped_handler_annotations["return"] == str


### PR DESCRIPTION
This pull request includes several changes to the `Makefile` and test files to improve the development workflow and enhance the test coverage. The most important changes involve updating the `Makefile` to include new targets for running tests and installing development dependencies, and renaming and modifying test functions for better clarity and functionality.

Makefile updates:

* Added new targets `run-test` and `dependencies-dev-install` to the `.PHONY` list in the `Makefile`.
* Updated the `run-test` target to depend on `dependencies-dev-install` instead of `dev-dependencies`.

Test file updates:

* Renamed `tests/core/utils/test_validate_and_wrap_handler.py` to `tests/core/utils/test_wrap_handler.py` to better reflect the functionality being tested.
* Modified test functions to use `wrap_handler` with updated parameters and added assertions for type annotations in `test_wrap_handler_base_model_input_str_output`. [[1]](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68L6-R12) [[2]](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68L22-R28) [[3]](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68L38-R38) [[4]](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68L48-R55)