### PR TITLE
43 bug when is not sent a content type json header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ install: ## Install the package
 
 ##@ Release commands
 
-alpha: ## Bump the version to alpha (BUMP_INCREMENT=PATCH|MINOR|MANOR, default: PATCH)
+alpha: ## Bump the version to alpha (BUMP_INCREMENT=PATCH|MINOR|MAYOR, default: PATCH)
 	cz bump --prerelease $@ --increment ${BUMP_INCREMENT}
 
-beta: ## Bump the version to beta (BUMP_INCREMENT=PATCH|MINOR|MANOR, default: PATCH)
+beta: ## Bump the version to beta (BUMP_INCREMENT=PATCH|MINOR|MAYOR, default: PATCH)
 	cz bump --prerelease $@ --increment ${BUMP_INCREMENT};
 
 dist: ## Build the distribution

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ install: ## Install the package
 
 ##@ Release commands
 
-alpha: ## Bump the version to alpha (BUMP_INCREMENT=PATCH|MINOR|MAYOR, default: PATCH)
+alpha: ## Bump the version to alpha (BUMP_INCREMENT=PATCH|MINOR|MAJOR, default: PATCH)
 	cz bump --prerelease $@ --increment ${BUMP_INCREMENT}
 
-beta: ## Bump the version to beta (BUMP_INCREMENT=PATCH|MINOR|MAYOR, default: PATCH)
+beta: ## Bump the version to beta (BUMP_INCREMENT=PATCH|MINOR|MAJOR, default: PATCH)
 	cz bump --prerelease $@ --increment ${BUMP_INCREMENT};
 
 dist: ## Build the distribution

--- a/inferia/core/app.py
+++ b/inferia/core/app.py
@@ -8,11 +8,12 @@ import uvicorn
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
+
 
 from inferia.api.handlers import (
     health_check_handler,
 )
-from inferia.core.utils import wrap_handler
 from inferia.api.responses import ErrorResponse
 from inferia.core.config import ConfigFile
 from inferia.core.exceptions import (
@@ -112,11 +113,11 @@ class Application:
         ):
             return JSONResponse(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                content={
+                content=jsonable_encoder({
                     "detail": "There is an error with the request parameters.",
                     "errors": exc.errors(),
                     "body": exc.body,
-                },
+                }),
             )
 
         self.app.add_exception_handler(

--- a/inferia/templates/predict_class_template.jinja2
+++ b/inferia/templates/predict_class_template.jinja2
@@ -20,7 +20,7 @@ class {{ route.class_name }}(BasePredictor):
     {%- endif %}
     """
 
-    def setup(self):
+    async def setup(self):
         """
         This method is called once before the first prediction is made.
         """


### PR DESCRIPTION
This pull request includes several updates to the `inferia` project, focusing on improving error handling, fixing typos, and updating imports. The most important changes include fixing a typo in the `Makefile`, updating the `setup` method to be asynchronous, and adding error handling for the application setup.

Error handling improvements:

* [`inferia/core/app.py`](diffhunk://#diff-c3817785377e2e279521faab493127188a8c6ac3707c3ce6458d065782641facL52-R63): Added error handling for the application setup by catching `SetupError` exceptions and logging critical errors before exiting the application.
* [`inferia/core/app.py`](diffhunk://#diff-c3817785377e2e279521faab493127188a8c6ac3707c3ce6458d065782641facL115-R129): Updated the `validation_exception_handler` to use `jsonable_encoder` for encoding the response content.

Code improvements:

* [`inferia/templates/predict_class_template.jinja2`](diffhunk://#diff-17c370427d53bc948cce14fef62f2912074cb5beb273b821e7643c9969ef52fcL23-R23): Updated the `setup` method in the `BasePredictor` class to be asynchronous.

Import updates:

* [`inferia/core/app.py`](diffhunk://#diff-c3817785377e2e279521faab493127188a8c6ac3707c3ce6458d065782641facR4-L15): Added missing imports for `sys` and `jsonable_encoder`.

Typo fixes:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L86-R89): Fixed a typo in the `alpha` and `beta` release commands by changing `MANOR` to `MAJOR`.