### PR TITLE
fix: Fix assert on test for base Model and ResultResponse. 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,10 @@ repos:
       - id: black
         files: \.py$  # This ensures black runs only on Python files
         exclude: ^\.venv/  # Excludes the virtual environment directory
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Run Pytest
+        entry: pytest --maxfail=1 --disable-warnings -q
+        language: system
+        types: [python]        

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,5 @@ repos:
     hooks:
       - id: pytest
         name: Run Pytest
-        entry: pytest --maxfail=1 --disable-warnings -q
+        entry: make run-test
         language: system
-        types: [python]        


### PR DESCRIPTION

This pull request includes several changes to improve the handling of asynchronous operations, testing, and pre-commit hooks. The most important changes include adding a new pre-commit hook for running Pytest, modifying the `wrap_handler` function to handle optional semaphores, and updating test cases to use `ResultResponse`.

### Pre-commit Hooks:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R8-R14): Added a new local pre-commit hook to run Pytest with specific options.

### Asynchronous Operations:
* [`inferia/core/utils.py`](diffhunk://#diff-298ceabc0bdff8e96d955b09093eebbfb6529827696e2fe69247adf2f01fbe54L62-R62): Modified the `wrap_handler` function to make the `semaphore` parameter optional by setting its default value to `None`.

### Code Annotations:
* [`inferia/core/utils.py`](diffhunk://#diff-298ceabc0bdff8e96d955b09093eebbfb6529827696e2fe69247adf2f01fbe54L148-R148): Simplified the handler annotations by directly using the `response_model` instead of its class.

### Testing:
* [`tests/core/utils/test_wrap_handler.py`](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68R1-R25): Updated the test cases to use `ResultResponse` for the wrapped handler's return value and adjusted assertions accordingly. [[1]](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68R1-R25) [[2]](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68L28-R43) [[3]](diffhunk://#diff-8b79ebfc4532c6cde65123d12d64c88cfd970c303ff3c6e71eb02d58300b2d68L48-R66)