### PR TITLE
refactor: move threads config to server node

### DIFF
--- a/examples/inferia.yaml
+++ b/examples/inferia.yaml
@@ -2,6 +2,7 @@ inferia:
   server:
     cache_dir: /tmp/inferia
     description: Inference server
+    threads: 4
     fastapi:
       access_log: true
       debug: false
@@ -10,9 +11,9 @@ inferia:
     name: Sapientia per Inferentiam
     route:
       args:
-      - description: The prompt to generate text from
-        name: prompt
-        type: str
+        - description: The prompt to generate text from
+          name: prompt
+          type: str
       description: Make a single prediction
       name: Predict
       path: /v1/predict
@@ -21,7 +22,6 @@ inferia:
         description: The generated text
         type: PredictResponse
       tags:
-      - predict
-      threads: 1
+        - predict
     version: 0.1.0
-  training: {}
+  training: { }

--- a/examples/predict.py
+++ b/examples/predict.py
@@ -1,6 +1,6 @@
 import logging
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from inferia import BasePredictor
 
@@ -11,7 +11,11 @@ class PredictResponse(BaseModel):
 
 
 class Predictor(BasePredictor):
-    def predict(self, *args, **kwargs) -> PredictResponse:
+    def predict(
+            self, prompt: str, temperature: float = Field(0.5,
+                                                          description="Temperature is the most important attribute for an inference",
+                                                          gt=0.0, lt=1.0)
+            ) -> PredictResponse:
         return PredictResponse(
                 image="https://example.com/image.jpg", text="Hello world"
         )

--- a/inferia/core/config.py
+++ b/inferia/core/config.py
@@ -30,27 +30,25 @@ class RouteConfig(BaseModel):
     args: Optional[List["ArgConfig"]] = None
     response: Optional["ResponseConfig"] = None
     tags: List[str] = List
-    threads: int
 
     @classmethod
     def default(cls):
         return cls(
-            name="Predict",
-            description="Make a single prediction",
-            path="/v1/predict",
-            predictor="predict:Predictor",
-            threads=1,
-            args=[
-                ArgConfig(
-                    name="prompt",
-                    type="str",
-                    description="The prompt to generate text from",
-                )
-            ],
-            response=ResponseConfig(
-                type="PredictResponse", description="The generated text"
-            ),
-            tags=["predict"],
+                name="Predict",
+                description="Make a single prediction",
+                path="/v1/predict",
+                predictor="predict:Predictor",
+                args=[
+                    ArgConfig(
+                            name="prompt",
+                            type="str",
+                            description="The prompt to generate text from",
+                    )
+                ],
+                response=ResponseConfig(
+                        type="PredictResponse", description="The generated text"
+                ),
+                tags=["predict"],
         )
 
 
@@ -76,16 +74,18 @@ class ServerConfig(BaseModel):
     fastapi: FastAPIConfig
     route: RouteConfig
     cache_dir: str = None
+    threads: int
 
     @classmethod
     def default(cls):
         return cls(
-            name="Sapientia per Inferentiam",
-            description="Inference server",
-            version="0.1.0",
-            fastapi=FastAPIConfig.default(),
-            route=RouteConfig.default(),
-            cache_dir="/tmp/inferia",
+                name="Sapientia per Inferentiam",
+                description="Inference server",
+                version="0.1.0",
+                fastapi=FastAPIConfig.default(),
+                route=RouteConfig.default(),
+                cache_dir="/tmp/inferia",
+                threads=1,
         )
 
 

--- a/inferia/core/utils.py
+++ b/inferia/core/utils.py
@@ -176,7 +176,7 @@ def model_download(model_path: str) -> str:
 def create_routes_semaphores(config: InferiaConfig) -> Dict[str, asyncio.Semaphore]:
     semaphores = {}
     route = config.server.route
-    semaphores[route.predictor] = asyncio.Semaphore(route.threads)
+    semaphores[route.predictor] = asyncio.Semaphore(config.server.threads)
 
     return semaphores
 


### PR DESCRIPTION
This pull request includes several changes to improve the threading configuration and enhance the `Predictor` class in the `inferia` project. The most important changes include adding a `threads` configuration to the server settings, updating the `Predictor` class to include a `temperature` parameter, and modifying the threading logic in the `create_routes_semaphores` function.

Threading configuration improvements:

* [`examples/inferia.yaml`](diffhunk://#diff-feaaa210ecc37753bd1943b510dd7fa0e6c120844e78670378766c4927973ab5R5): Added a `threads` parameter to the server configuration and removed the `threads` parameter from the route configuration. [[1]](diffhunk://#diff-feaaa210ecc37753bd1943b510dd7fa0e6c120844e78670378766c4927973ab5R5) [[2]](diffhunk://#diff-feaaa210ecc37753bd1943b510dd7fa0e6c120844e78670378766c4927973ab5L25)
* [`inferia/core/config.py`](diffhunk://#diff-ddaaebfdbeff10f0618dcbdb3ef06375be693813248eba66f81e082a21d9ad62L33): Added a `threads` parameter to the `ServerConfig` class and removed it from the `RouteConfig` class. Updated the `default` methods accordingly. [[1]](diffhunk://#diff-ddaaebfdbeff10f0618dcbdb3ef06375be693813248eba66f81e082a21d9ad62L33) [[2]](diffhunk://#diff-ddaaebfdbeff10f0618dcbdb3ef06375be693813248eba66f81e082a21d9ad62L42) [[3]](diffhunk://#diff-ddaaebfdbeff10f0618dcbdb3ef06375be693813248eba66f81e082a21d9ad62R77) [[4]](diffhunk://#diff-ddaaebfdbeff10f0618dcbdb3ef06375be693813248eba66f81e082a21d9ad62R88)

Enhancements to `Predictor` class:

* [`examples/predict.py`](diffhunk://#diff-0aae350a4ae0b1b8dc4af9607c5a85f5941091eae5f3939363a70768089ec64fL3-R3): Updated the `Predictor` class to include a `temperature` parameter with validation using `Field` from `pydantic`. [[1]](diffhunk://#diff-0aae350a4ae0b1b8dc4af9607c5a85f5941091eae5f3939363a70768089ec64fL3-R3) [[2]](diffhunk://#diff-0aae350a4ae0b1b8dc4af9607c5a85f5941091eae5f3939363a70768089ec64fL14-R18)

Threading logic modification:

* [`inferia/core/utils.py`](diffhunk://#diff-298ceabc0bdff8e96d955b09093eebbfb6529827696e2fe69247adf2f01fbe54L179-R179): Modified the `create_routes_semaphores` function to use the `threads` parameter from the server configuration instead of the route configuration.