### PR TITLE
refactor(.github/workflows/publish-to-pypi-and-test-pypi.yml): Update…

### DIFF
--- a/.github/workflows/publish-to-pypi-and-test-pypi.yml
+++ b/.github/workflows/publish-to-pypi-and-test-pypi.yml
@@ -47,7 +47,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
… Sigstore Python action to version 3.0.0

- Replace existing Sigstore action with updated version v3.0.0
- Adjust the usage of Sigstore action with new input structure
- Modify GitHub Release steps to upload signatures using the new Sigstore action