### PR TITLE
chore(Makefile): Simplify virtual environment activation commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ REPOSITORY?=testpypi
 
 BUMP_INCREMENT?="PATCH"
 
+VENV=.venv
+ACTIVATE=. $(VENV)/bin/activate
 
 all: help
 
@@ -48,10 +50,10 @@ git-prune: ## Prune the git repository
 	@rm .branches_to_delete
 
 code-style-check: ## Checks the code style.
-	@. .venv/bin/activate && black --check .
+	@$(ACTIVATE) && black --check .
 
 code-style-dirty: ## Fixes the code style but does not commit the changes
-	@. .venv/bin/activate && black .
+	@$(ACTIVATE) && black .
 
 code-style: code-style-dirty ## Check the code style and commit the changes
 	@git commit -am "style: fix code style"
@@ -62,24 +64,24 @@ pre-commit-install: ## Install pre-commit hooks
 ##@ Dependencies management commands
 
 dependencies-compile: ## Compile the dependencies
-	@. .venv/bin/activate && uv pip compile --universal -o requirements.txt --no-deps --no-annotate --no-header pyproject.toml
+	@$(ACTIVATE) && uv pip compile --universal -o requirements.txt --no-deps --no-annotate --no-header pyproject.toml
 
 dependencies-install: ## Install the dependencies
-	@. .venv/bin/activate && uv sync
+	@$(ACTIVATE) && uv sync
 
 dependencies-dev-install: .venv ## Install the development dependencies
-	@. .venv/bin/activate && uv pip install -e .
-	@. .venv/bin/activate && uv sync --dev
+	@$(ACTIVATE) && uv pip install -e .
+	@$(ACTIVATE) && uv sync --dev
 
 ##@ Testing commands
 
 run-test: .venv dependencies-dev-install ## Run the tests
-	@. .venv/bin/activate && python -m pytest
+	@$(ACTIVATE) && python -m pytest
 
 ##@ Install
 
 install: ## Install the package
-	@. .venv/bin/activate && pip install -e .
+	@$(ACTIVATE) && pip install -e .
 
 ##@ Release commands
 


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to streamline the activation of the virtual environment by using a variable for the activation command. The most important changes are as follows:

Improvements to virtual environment activation:

* Added variables `VENV` and `ACTIVATE` to define the virtual environment directory and activation command. (`Makefile` [MakefileR8-R9](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R8-R9))
* Updated the `code-style-check` and `code-style-dirty` targets to use the `ACTIVATE` variable for activating the virtual environment. (`Makefile` [MakefileL51-R56](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L51-R56))
* Modified the `dependencies-compile`, `dependencies-install`, `dependencies-dev-install`, `run-test`, and `install` targets to use the `ACTIVATE` variable for virtual environment activation. (`Makefile` [MakefileL65-R84](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L65-R84))