### PR TITLE
feat: show global options in command help

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,6 +851,7 @@ cogito-cli [COMMAND] --help
 **Behavior:**
 - Displays a list of available commands when used without arguments
 - Shows detailed help information for a specific command when used with a command name
+- Shows applicable global options, such as `-c, --config-path`, in command help
 - Includes information about available options, arguments, and basic usage examples
 - Can be used with any command or subcommand to get context-specific help
 

--- a/cogito/commands/_help.py
+++ b/cogito/commands/_help.py
@@ -1,0 +1,38 @@
+"""Click command classes for displaying root options in nested help."""
+
+import click
+
+
+class _RootOptionsHelpMixin:
+    """Append the root command's options to nested command help."""
+
+    def format_options(
+        self, ctx: click.Context, formatter: click.HelpFormatter
+    ) -> None:
+        super().format_options(ctx, formatter)
+
+        root_ctx = ctx.find_root()
+        if root_ctx is ctx:
+            return
+
+        help_records = []
+        for param in root_ctx.command.get_params(root_ctx):
+            if not isinstance(param, click.Option) or param.name == "help":
+                continue
+            help_record = param.get_help_record(root_ctx)
+            if help_record is not None:
+                help_records.append(help_record)
+
+        if help_records:
+            with formatter.section("Global Options"):
+                formatter.write_dl(help_records)
+
+
+class RootOptionsCommand(_RootOptionsHelpMixin, click.Command):
+    """Command that includes applicable root options in its help."""
+
+
+class RootOptionsGroup(_RootOptionsHelpMixin, click.Group):
+    """Group that includes applicable root options in its help."""
+
+    command_class = RootOptionsCommand

--- a/cogito/commands/config.py
+++ b/cogito/commands/config.py
@@ -1,10 +1,11 @@
 import click
 
+from cogito.commands._help import RootOptionsGroup
 from cogito.core.exceptions import ConfigFileNotFoundError
 from cogito.core.config.file import ConfigFile
 
 
-@click.group()
+@click.group(cls=RootOptionsGroup)
 @click.pass_obj
 def config(ctx: click.Context) -> None:
     """Configuration management commands."""

--- a/cogito/commands/initialize.py
+++ b/cogito/commands/initialize.py
@@ -1,5 +1,6 @@
 import click
 
+from cogito.commands._help import RootOptionsCommand
 from cogito.commands.scaffold import scaffold_predict_classes
 from cogito.core.config.file import ConfigFile
 
@@ -110,7 +111,7 @@ def _init_prompted() -> ConfigFile:
     return ConfigFile(cogito=cogito)
 
 
-@click.command()
+@click.command(cls=RootOptionsCommand)
 @click.option(
     "-s",
     "--scaffold",

--- a/cogito/commands/predict.py
+++ b/cogito/commands/predict.py
@@ -2,11 +2,12 @@ import json
 
 import click
 
+from cogito.commands._help import RootOptionsCommand
 from cogito.core.exceptions import ConfigFileNotFoundError, NoSetupMethodError
 from cogito.lib.prediction import Predict
 
 
-@click.command()
+@click.command(cls=RootOptionsCommand)
 @click.option(
     "--payload", type=str, required=True, help="The payload for the prediction"
 )

--- a/cogito/commands/run.py
+++ b/cogito/commands/run.py
@@ -4,9 +4,10 @@ import sys
 import click
 
 from cogito import Application
+from cogito.commands._help import RootOptionsCommand
 
 
-@click.command()
+@click.command(cls=RootOptionsCommand)
 @click.pass_obj
 def run(ctx: click.Context) -> None:
     """Run cogito app"""

--- a/cogito/commands/scaffold.py
+++ b/cogito/commands/scaffold.py
@@ -3,6 +3,7 @@ import os
 import click
 from jinja2 import Environment, FileSystemLoader
 
+from cogito.commands._help import RootOptionsCommand
 from cogito.core.config.file import ConfigFile
 from cogito.core.exceptions import ConfigFileNotFoundError
 
@@ -88,7 +89,7 @@ def scaffold_train_classes(config: ConfigFile, force: bool = False) -> bool:
     return True
 
 
-@click.command()
+@click.command(cls=RootOptionsCommand)
 @click.option(
     "-f",
     "--force",

--- a/cogito/commands/train.py
+++ b/cogito/commands/train.py
@@ -2,11 +2,12 @@ import json
 
 import click
 
+from cogito.commands._help import RootOptionsCommand
 from cogito.core.exceptions import ConfigFileNotFoundError, NoSetupMethodError
 from cogito.lib.training import Trainer
 
 
-@click.command()
+@click.command(cls=RootOptionsCommand)
 @click.option("--payload", type=str, required=True, help="The payload for the training")
 @click.pass_obj
 def train(ctx: click.Context, payload: str) -> None:

--- a/tests/commands/test_help.py
+++ b/tests/commands/test_help.py
@@ -1,0 +1,42 @@
+import pytest
+from click.testing import CliRunner
+
+from cogito.cli import cli
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["init", "--help"],
+        ["scaffold", "--help"],
+        ["run", "--help"],
+        ["predict", "--help"],
+        ["train", "--help"],
+        ["config", "--help"],
+        ["config", "version", "--help"],
+        ["config", "upgrade", "--help"],
+    ],
+)
+def test_config_dependent_command_help_includes_root_options(args):
+    result = CliRunner().invoke(cli, args)
+
+    assert result.exit_code == 0
+    assert "Global Options:" in result.output
+    assert "-c, --config-path TEXT" in result.output
+    assert "The path to the configuration file" in result.output
+
+
+def test_root_help_does_not_repeat_root_options():
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Global Options:" not in result.output
+    assert result.output.count("--config-path") == 1
+
+
+def test_version_help_omits_unused_config_option():
+    result = CliRunner().invoke(cli, ["version", "--help"])
+
+    assert result.exit_code == 0
+    assert "Global Options:" not in result.output
+    assert "--config-path" not in result.output


### PR DESCRIPTION
## Summary

- add reusable Click command/group classes that show applicable root options in nested help
- expose `--config-path` under a clearly labeled `Global Options` section for configuration-dependent commands
- cover every affected command, nested `config` commands, root-help deduplication, and the configuration-independent `version` command

Closes #124.

## Testing

- `uv sync --dev --frozen`
- `python -m pytest` — 45 passed
- `python -m pytest tests/commands/test_help.py` — 10 passed
- Black check on all touched Python files
- flake8 on the two new files
- `git diff --check`

## Limitations

- This changes help presentation only; Click still parses root options in its existing root-command position.
- The repository-wide `make code-style-check` remains red on three untouched baseline files (`cogito/api/responses.py`, `cogito/core/config/file.py`, and `cogito/core/utils.py`). All touched Python files pass Black, and the new files pass flake8.

Tooling disclosure: this change was prepared with OpenAI Codex and validated with the commands above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text formatting only; no changes to option parsing, config loading, or command execution paths.
> 
> **Overview**
> Nested `cogito-cli` help now surfaces root-level flags (notably **`-c, --config-path`**) under a **Global Options** section, so users see config-related flags when running `command --help` without re-reading top-level help.
> 
> Adds reusable Click `RootOptionsCommand` / `RootOptionsGroup` helpers that extend `format_options` to copy non-`help` root options from the root context. Config-aware commands (`init`, `scaffold`, `run`, `predict`, `train`, and the `config` group including subcommands) adopt these classes; root `--help` and the package `version` command are unchanged so options are not duplicated or shown where they do not apply. README and CLI tests document and lock in the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6de542aa9ef1fad2662e4d93c67aeb2946b8af02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->